### PR TITLE
feat!: Align module with new provider changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,21 @@ module "terraform_snowflake_user" {
 }
 ```
 
----
+## Breaking changes in v2.x of the module
+
+Due to breaking changes in Snowflake provider and additional code optimizations, **breaking changes** were introduced in `v2.0.0` version of this module.
+
+List of code and variable (API) changes:
+
+* Support for Snowflake user types, managed by `type` variable
+* Clear differentiation of `PERSON`, `SERVICE` and `LEGACY_SERVICE` users
+* `snowflake_default_secondary_roles` changed to `snowflake_default_secondary_roles_option` (string)
+* Added `middle_name`, `query_tag`, `timezone`, `network_policy`, `trace_level`, `log_level` and `enable_unredacted_query_syntax_error` variables
+* Added `disable_mfa` flag (`false` by default), that handles MFA enforcement for `PERSON` users
+
+When upgrading from `v1.x`, expect most of the resources to be recreated - if recreation is impossible, then it is possible to import some existing resources.
+
+For more information, refer to [variables.tf](variables.tf), list of inputs below and Snowflake provider documentation
 
 <!-- BEGIN_TF_DOCS -->
 
@@ -45,36 +59,45 @@ module "terraform_snowflake_user" {
 | <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "descriptor_formats": {},<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "labels_as_tags": [<br>    "unset"<br>  ],<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {},<br>  "tenant": null<br>}</pre> | no |
 | <a name="input_default_namespace"></a> [default\_namespace](#input\_default\_namespace) | Specifies the namespace (database only or database and schema) that is active by default for the user's session upon login. | `string` | `null` | no |
 | <a name="input_default_role"></a> [default\_role](#input\_default\_role) | Specifies the role that is active by default for the user's session upon login. | `string` | `null` | no |
-| <a name="input_default_secondary_roles"></a> [default\_secondary\_roles](#input\_default\_secondary\_roles) | Specifies the set of secondary roles that are active for the user's session upon login. <br>    Secondary roles are a set of roles that authorize any SQL action other than the execution of CREATE <object> statements. <br>    Currently only ["ALL"] value is supported | `list(string)` | `[]` | no |
+| <a name="input_default_secondary_roles_option"></a> [default\_secondary\_roles\_option](#input\_default\_secondary\_roles\_option) | Specifies the secondary roles that are active for the user’s session upon login. <br>    Valid values are (case-insensitive): DEFAULT \| NONE \| ALL | `string` | `"DEFAULT"` | no |
 | <a name="input_default_warehouse"></a> [default\_warehouse](#input\_default\_warehouse) | Specifies the virtual warehouse that is active by default for the user's session upon login. | `string` | `null` | no |
 | <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between ID elements.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
 | <a name="input_descriptor_formats"></a> [descriptor\_formats](#input\_descriptor\_formats) | Describe additional descriptors to be output in the `descriptors` output map.<br>Map of maps. Keys are names of descriptors. Values are maps of the form<br>`{<br>   format = string<br>   labels = list(string)<br>}`<br>(Type is `any` so the map values can later be enhanced to provide additional options.)<br>`format` is a Terraform format string to be passed to the `format()` function.<br>`labels` is a list of labels, in order, to pass to `format()` function.<br>Label values will be normalized before being passed to `format()` so they will be<br>identical to how they appear in `id`.<br>Default is `{}` (`descriptors` output will be empty). | `any` | `{}` | no |
 | <a name="input_descriptor_name"></a> [descriptor\_name](#input\_descriptor\_name) | Name of the descriptor used to form a Snowflake User name | `string` | `"snowflake-user"` | no |
+| <a name="input_disable_mfa"></a> [disable\_mfa](#input\_disable\_mfa) | Disable Multi-Factor Authentication for the user (works only with `type = PERSON`) | `bool` | `false` | no |
 | <a name="input_display_name"></a> [display\_name](#input\_display\_name) | Name displayed for the user in the Snowflake web interface. | `string` | `null` | no |
 | <a name="input_email"></a> [email](#input\_email) | Email address for the user | `string` | `null` | no |
+| <a name="input_enable_unredacted_query_syntax_error"></a> [enable\_unredacted\_query\_syntax\_error](#input\_enable\_unredacted\_query\_syntax\_error) | Controls whether query text is redacted if a SQL query fails due to a syntax or parsing error. If FALSE, the content of a failed query is redacted in the views, pages, and functions that provide a query history. <br>    Only users with a role that is granted or inherits the AUDIT privilege can set the ENABLE\_UNREDACTED\_QUERY\_SYNTAX\_ERROR parameter. <br>    When using the ALTER USER command to set the parameter to TRUE for a particular user, modify the user that you want to see the query text, not the user who executed the query (if those are different users). | `bool` | `null` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
-| <a name="input_first_name"></a> [first\_name](#input\_first\_name) | First name of the user | `string` | `null` | no |
+| <a name="input_first_name"></a> [first\_name](#input\_first\_name) | First name of the user (works only with `type = PERSON`) | `string` | `null` | no |
 | <a name="input_generate_password"></a> [generate\_password](#input\_generate\_password) | Generate a random password using Terraform | `bool` | `false` | no |
 | <a name="input_generate_rsa_key"></a> [generate\_rsa\_key](#input\_generate\_rsa\_key) | Whether automatically generate an RSA key - IMPORTANT <br>    The private key generated by this resource will be stored <br>    unencrypted in your Terraform state file. <br>    Use of this resource for production deployments is not recommended. | `bool` | `false` | no |
 | <a name="input_grant_default_roles"></a> [grant\_default\_roles](#input\_grant\_default\_roles) | Whether to grant default\_role to Snowflake User | `bool` | `true` | no |
 | <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for keep the existing setting, which defaults to `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
-| <a name="input_ignore_changes_on_defaults"></a> [ignore\_changes\_on\_defaults](#input\_ignore\_changes\_on\_defaults) | Whether to ignore configuration of `default_warehouse`, `default_role` and `default_namespace` | `bool` | `false` | no |
+| <a name="input_ignore_changes_on_defaults"></a> [ignore\_changes\_on\_defaults](#input\_ignore\_changes\_on\_defaults) | Whether to ignore configuration of `default_warehouse`, `default_role` and `default_namespace` (works only with `type = PERSON`) | `bool` | `false` | no |
 | <a name="input_label_key_case"></a> [label\_key\_case](#input\_label\_key\_case) | Controls the letter case of the `tags` keys (label names) for tags generated by this module.<br>Does not affect keys of tags passed in via the `tags` input.<br>Possible values: `lower`, `title`, `upper`.<br>Default value: `title`. | `string` | `null` | no |
 | <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The order in which the labels (ID elements) appear in the `id`.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present. | `list(string)` | `null` | no |
 | <a name="input_label_value_case"></a> [label\_value\_case](#input\_label\_value\_case) | Controls the letter case of ID elements (labels) as included in `id`,<br>set as tag values, and output by this module individually.<br>Does not affect values of tags passed in via the `tags` input.<br>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br>Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.<br>Default value: `lower`. | `string` | `null` | no |
 | <a name="input_labels_as_tags"></a> [labels\_as\_tags](#input\_labels\_as\_tags) | Set of labels (ID elements) to include as tags in the `tags` output.<br>Default is to include all labels.<br>Tags with empty values will not be included in the `tags` output.<br>Set to `[]` to suppress all generated tags.<br>**Notes:**<br>  The value of the `name` tag, if included, will be the `id`, not the `name`.<br>  Unlike other `null-label` inputs, the initial setting of `labels_as_tags` cannot be<br>  changed in later chained modules. Attempts to change it will be silently ignored. | `set(string)` | <pre>[<br>  "default"<br>]</pre> | no |
-| <a name="input_last_name"></a> [last\_name](#input\_last\_name) | Last name of the user | `string` | `null` | no |
+| <a name="input_last_name"></a> [last\_name](#input\_last\_name) | Last name of the user (works only with `type = PERSON`) | `string` | `null` | no |
+| <a name="input_log_level"></a> [log\_level](#input\_log\_level) | Specifies the severity level of messages that should be ingested and made available in the active event table. Messages at the specified level (and at more severe levels) are ingested. | `string` | `null` | no |
 | <a name="input_login_name"></a> [login\_name](#input\_login\_name) | The name users use to log in. If not supplied, snowflake will use name instead. | `string` | `null` | no |
+| <a name="input_middle_name"></a> [middle\_name](#input\_middle\_name) | Middle name of the user (works only with `type = PERSON`) | `string` | `null` | no |
 | <a name="input_must_change_password"></a> [must\_change\_password](#input\_must\_change\_password) | Should the user change the password on login. Should be set to true for non service account users | `bool` | `true` | no |
 | <a name="input_name"></a> [name](#input\_name) | ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.<br>This is the only ID element not also included as a `tag`.<br>The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input. | `string` | `null` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique | `string` | `null` | no |
+| <a name="input_network_policy"></a> [network\_policy](#input\_network\_policy) | Specifies the network policy to enforce for your account. Network policies enable restricting access to your account based on users’ IP address. | `string` | `null` | no |
+| <a name="input_query_tag"></a> [query\_tag](#input\_query\_tag) | Optional string that can be used to tag queries and other SQL statements executed within a session. | `string` | `null` | no |
 | <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br>Characters matching the regex will be removed from the ID elements.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | <a name="input_rsa_public_key"></a> [rsa\_public\_key](#input\_rsa\_public\_key) | Specifies the user's RSA public key; used for key-pair authentication. Must be on 1 line without header and trailer. | `string` | `null` | no |
 | <a name="input_rsa_public_key_2"></a> [rsa\_public\_key\_2](#input\_rsa\_public\_key\_2) | Specifies the user's second RSA public key; used to rotate the public and private keys <br>    for key-pair authentication based on an expiration schedule set by your organization. <br>    Must be on 1 line without header and trailer." | `string` | `null` | no |
 | <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
 | <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |
+| <a name="input_timezone"></a> [timezone](#input\_timezone) | Specifies the time zone for the session. You can specify a time zone name or a link name from release 2021a of the IANA Time Zone Database (e.g. America/Los\_Angeles, Europe/London, UTC, Etc/GMT, etc.). | `string` | `null` | no |
+| <a name="input_trace_level"></a> [trace\_level](#input\_trace\_level) | Controls how trace events are ingested into the event table. | `string` | `null` | no |
+| <a name="input_type"></a> [type](#input\_type) | Type of the user. Valid values are PERSON, SERVICE, LEGACY\_SERVICE | `string` | `"PERSON"` | no |
 
 ## Modules
 
@@ -89,23 +112,33 @@ module "terraform_snowflake_user" {
 |------|-------------|
 | <a name="output_default_namespace"></a> [default\_namespace](#output\_default\_namespace) | Specifies the namespace (database only or database and schema) that is active by default for the user's session upon login |
 | <a name="output_default_role"></a> [default\_role](#output\_default\_role) | Specifies the role that is active by default for the user's session upon login |
+| <a name="output_default_secondary_roles_option"></a> [default\_secondary\_roles\_option](#output\_default\_secondary\_roles\_option) | Specifies the secondary roles that are active for the user’s session upon login |
 | <a name="output_default_warehouse"></a> [default\_warehouse](#output\_default\_warehouse) | Specifies the virtual warehouse that is active by default for the user's session upon login |
+| <a name="output_disable_mfa"></a> [disable\_mfa](#output\_disable\_mfa) | Whether multi-factor authentication is disabled for the user |
 | <a name="output_disabled"></a> [disabled](#output\_disabled) | Whether user account is disabled |
 | <a name="output_display_name"></a> [display\_name](#output\_display\_name) | Name displayed for the user in the Snowflake web interface |
 | <a name="output_email"></a> [email](#output\_email) | Email address for the user |
-| <a name="output_first_name"></a> [first\_name](#output\_first\_name) | First name of the user |
-| <a name="output_last_name"></a> [last\_name](#output\_last\_name) | Last name of the user |
+| <a name="output_enable_unredacted_query_syntax_error"></a> [enable\_unredacted\_query\_syntax\_error](#output\_enable\_unredacted\_query\_syntax\_error) | Enable access to unredacted query syntax error for the user |
+| <a name="output_first_name"></a> [first\_name](#output\_first\_name) | First name of the user (only if `type == PERSON`) |
+| <a name="output_last_name"></a> [last\_name](#output\_last\_name) | Last name of the user (only if `type == PERSON`) |
+| <a name="output_log_level"></a> [log\_level](#output\_log\_level) | Log level |
 | <a name="output_login_name"></a> [login\_name](#output\_login\_name) | The name users use to log in |
+| <a name="output_middle_name"></a> [middle\_name](#output\_middle\_name) | Middle name of the user (only if `type == PERSON`) |
 | <a name="output_name"></a> [name](#output\_name) | Name of the user |
-| <a name="output_password"></a> [password](#output\_password) | Password set for the user |
+| <a name="output_network_policy"></a> [network\_policy](#output\_network\_policy) | Network policy associated with the user |
+| <a name="output_password"></a> [password](#output\_password) | Password set for the user (only if `type == PERSON` or `type == LEGACY_SERVICE`) |
+| <a name="output_query_tag"></a> [query\_tag](#output\_query\_tag) | Query tag |
 | <a name="output_rsa_private_key"></a> [rsa\_private\_key](#output\_rsa\_private\_key) | RSA Private key used for authentication |
+| <a name="output_timezone"></a> [timezone](#output\_timezone) | Timezone |
+| <a name="output_trace_level"></a> [trace\_level](#output\_trace\_level) | Trace level |
+| <a name="output_type"></a> [type](#output\_type) | User type |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.0.0 |
-| <a name="provider_snowflake"></a> [snowflake](#provider\_snowflake) | ~> 0.94 |
+| <a name="provider_snowflake"></a> [snowflake](#provider\_snowflake) | ~> 0.96 |
 | <a name="provider_tls"></a> [tls](#provider\_tls) | ~> 4.0 |
 
 ## Requirements
@@ -114,7 +147,7 @@ module "terraform_snowflake_user" {
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0.0 |
-| <a name="requirement_snowflake"></a> [snowflake](#requirement\_snowflake) | ~> 0.94 |
+| <a name="requirement_snowflake"></a> [snowflake](#requirement\_snowflake) | ~> 0.96 |
 | <a name="requirement_tls"></a> [tls](#requirement\_tls) | ~> 4.0 |
 
 ## Resources
@@ -123,6 +156,8 @@ module "terraform_snowflake_user" {
 |------|------|
 | [random_password.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [snowflake_grant_account_role.default_role](https://registry.terraform.io/providers/Snowflake-Labs/snowflake/latest/docs/resources/grant_account_role) | resource |
+| [snowflake_legacy_service_user.this](https://registry.terraform.io/providers/Snowflake-Labs/snowflake/latest/docs/resources/legacy_service_user) | resource |
+| [snowflake_service_user.this](https://registry.terraform.io/providers/Snowflake-Labs/snowflake/latest/docs/resources/service_user) | resource |
 | [snowflake_user.defaults_not_enforced](https://registry.terraform.io/providers/Snowflake-Labs/snowflake/latest/docs/resources/user) | resource |
 | [snowflake_user.this](https://registry.terraform.io/providers/Snowflake-Labs/snowflake/latest/docs/resources/user) | resource |
 | [tls_private_key.this](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -58,6 +58,8 @@ terraform destroy -var-file=fixtures.tfvars
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_terraform_snowflake_legacy_service_user"></a> [terraform\_snowflake\_legacy\_service\_user](#module\_terraform\_snowflake\_legacy\_service\_user) | ../../ | n/a |
+| <a name="module_terraform_snowflake_service_user"></a> [terraform\_snowflake\_service\_user](#module\_terraform\_snowflake\_service\_user) | ../../ | n/a |
 | <a name="module_terraform_snowflake_user_1"></a> [terraform\_snowflake\_user\_1](#module\_terraform\_snowflake\_user\_1) | ../../ | n/a |
 | <a name="module_terraform_snowflake_user_2"></a> [terraform\_snowflake\_user\_2](#module\_terraform\_snowflake\_user\_2) | ../../ | n/a |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
@@ -66,21 +68,23 @@ terraform destroy -var-file=fixtures.tfvars
 
 | Name | Description |
 |------|-------------|
-| <a name="output_user_module_outputs_1"></a> [user\_module\_outputs\_1](#output\_user\_module\_outputs\_1) | All user module outputs |
-| <a name="output_user_module_outputs_2"></a> [user\_module\_outputs\_2](#output\_user\_module\_outputs\_2) | All user module outputs |
+| <a name="output_legacy_service_user"></a> [legacy\_service\_user](#output\_legacy\_service\_user) | value of the legacy\_service\_user output |
+| <a name="output_service_user"></a> [service\_user](#output\_service\_user) | All user module outputs |
+| <a name="output_user_1"></a> [user\_1](#output\_user\_1) | All user module outputs |
+| <a name="output_user_2"></a> [user\_2](#output\_user\_2) | All user module outputs |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_snowflake"></a> [snowflake](#provider\_snowflake) | ~> 0.94 |
+| <a name="provider_snowflake"></a> [snowflake](#provider\_snowflake) | ~> 0.96 |
 
 ## Requirements
 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_snowflake"></a> [snowflake](#requirement\_snowflake) | ~> 0.94 |
+| <a name="requirement_snowflake"></a> [snowflake](#requirement\_snowflake) | ~> 0.96 |
 
 ## Resources
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -3,25 +3,78 @@ resource "snowflake_account_role" "user_role" {
 }
 
 module "terraform_snowflake_user_1" {
-  source            = "../../"
-  context           = module.this.context
-  name              = "snowflake_user_1"
-  generate_rsa_key  = true
-  generate_password = true
+  source  = "../../"
+  context = module.this.context
+  name    = "snowflake_user_1"
+  comment = "Example Snowflake User"
 
-  default_role            = resource.snowflake_account_role.user_role.name
-  default_secondary_roles = ["ALL"]
+  generate_rsa_key     = true
+  generate_password    = true
+  must_change_password = true
+
+  email        = "test@example.com"
+  first_name   = "John"
+  middle_name  = "Jack"
+  last_name    = "Doe"
+  display_name = "John Doe"
+
+  query_tag                            = "USER_1"
+  timezone                             = "Europe/Warsaw"
+  enable_unredacted_query_syntax_error = false
+  disable_mfa                          = false
+
+  default_role                   = resource.snowflake_account_role.user_role.name
+  default_secondary_roles_option = "ALL"
 }
 
 module "terraform_snowflake_user_2" {
   source                     = "../../"
   context                    = module.this.context
   name                       = "snowflake_user_2"
+  type                       = "PERSON"
   generate_rsa_key           = true
   generate_password          = true
+  must_change_password       = true
   ignore_changes_on_defaults = false
   grant_default_roles        = true
 
-  default_role            = resource.snowflake_account_role.user_role.name
-  default_secondary_roles = ["ALL"]
+  email        = "user@example.com"
+  first_name   = "Jane"
+  middle_name  = "Kate"
+  last_name    = "Doe"
+  display_name = "Jane Doe"
+
+  query_tag                            = "USER_2"
+  timezone                             = "Europe/Warsaw"
+  enable_unredacted_query_syntax_error = true
+  disable_mfa                          = true
+
+  default_role                   = resource.snowflake_account_role.user_role.name
+  default_secondary_roles_option = "NONE"
+}
+
+module "terraform_snowflake_service_user" {
+  source           = "../../"
+  context          = module.this.context
+  type             = "SERVICE"
+  name             = "service_user"
+  comment          = "Example Snowflake Service User"
+  generate_rsa_key = true
+
+
+  query_tag   = "SERVICE_USER"
+  log_level   = "ERROR"
+  trace_level = "ON_EVENT"
+
+  default_secondary_roles_option = "NONE"
+}
+
+module "terraform_snowflake_legacy_service_user" {
+  source            = "../../"
+  context           = module.this.context
+  type              = "LEGACY_SERVICE"
+  name              = "legacy_service_user"
+  generate_password = true
+
+  query_tag = "LEGACY_SERVICE_USER"
 }

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -1,11 +1,23 @@
-output "user_module_outputs_1" {
+output "user_1" {
   description = "All user module outputs"
   value       = module.terraform_snowflake_user_1
   sensitive   = true
 }
 
-output "user_module_outputs_2" {
+output "user_2" {
   description = "All user module outputs"
-  value       = module.terraform_snowflake_user_1
+  value       = module.terraform_snowflake_user_2
+  sensitive   = true
+}
+
+output "service_user" {
+  description = "All user module outputs"
+  value       = module.terraform_snowflake_service_user
+  sensitive   = true
+}
+
+output "legacy_service_user" {
+  description = "value of the legacy_service_user output"
+  value       = module.terraform_snowflake_legacy_service_user
   sensitive   = true
 }

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     snowflake = {
       source  = "Snowflake-Labs/snowflake"
-      version = "~> 0.94"
+      version = "~> 0.96"
     }
   }
 }

--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -57,7 +57,7 @@ No providers.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_snowflake"></a> [snowflake](#requirement\_snowflake) | ~> 0.94 |
+| <a name="requirement_snowflake"></a> [snowflake](#requirement\_snowflake) | ~> 0.96 |
 
 ## Resources
 

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -1,4 +1,4 @@
 module "terraform_snowflake_user" {
   source = "../../"
-  name   = "snowflake-user"
+  name   = "snowflake_user"
 }

--- a/examples/simple/outputs.tf
+++ b/examples/simple/outputs.tf
@@ -4,7 +4,7 @@ output "display_name" {
 }
 output "login_name" {
   description = "The name users use to log in"
-  value       = module.terraform_snowflake_user.login_name
+  value       = nonsensitive(module.terraform_snowflake_user.login_name)
 }
 output "default_role" {
   description = "Specifies the role that is active by default for the user's session upon login"

--- a/examples/simple/versions.tf
+++ b/examples/simple/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     snowflake = {
       source  = "Snowflake-Labs/snowflake"
-      version = "~> 0.94"
+      version = "~> 0.96"
     }
   }
 }

--- a/locals.tf
+++ b/locals.tf
@@ -7,5 +7,5 @@ locals {
   generate_password = module.this.enabled && var.generate_password
   generate_rsa_key  = module.this.enabled && var.generate_rsa_key
 
-  snowflake_user = var.ignore_changes_on_defaults ? snowflake_user.defaults_not_enforced : snowflake_user.this
+  snowflake_user = var.type == "SERVICE" ? one(snowflake_service_user.this[*]) : var.type == "LEGACY_SERVICE" ? one(snowflake_legacy_service_user.this[*]) : var.type == "PERSON" && var.ignore_changes_on_defaults ? one(snowflake_user.defaults_not_enforced[*]) : one(snowflake_user.this[*])
 }

--- a/main.tf
+++ b/main.tf
@@ -18,57 +18,77 @@ resource "tls_private_key" "this" {
 resource "random_password" "this" {
   count = module.this.enabled && local.generate_password ? 1 : 0
 
-  length           = 16
+  length           = 36
   special          = true
   override_special = "!#$%&*()-_=+[]{}<>:?"
 }
 
 resource "snowflake_user" "this" {
-  count = module.this.enabled && !var.ignore_changes_on_defaults ? 1 : 0
+  count = module.this.enabled && !var.ignore_changes_on_defaults && upper(var.type) == "PERSON" ? 1 : 0
 
   name         = local.name_from_descriptor
   login_name   = var.login_name
   display_name = var.display_name
   comment      = var.comment
 
-  password             = one(random_password.this[*].result)
+  password             = var.generate_password ? one(random_password.this[*].result) : null
   must_change_password = var.must_change_password
+  disable_mfa          = var.disable_mfa
 
-  email      = var.email
-  first_name = var.first_name
-  last_name  = var.last_name
+  email       = var.email
+  first_name  = var.first_name
+  middle_name = var.middle_name
+  last_name   = var.last_name
 
-  default_namespace       = var.default_namespace
-  default_warehouse       = var.default_warehouse
-  default_role            = var.default_role
-  default_secondary_roles = var.default_secondary_roles
+  default_namespace              = var.default_namespace
+  default_warehouse              = var.default_warehouse
+  default_role                   = var.default_role
+  default_secondary_roles_option = var.default_secondary_roles_option #'DEFAULT', 'ALL', 'NONE'
 
   rsa_public_key   = local.rsa_public_key
   rsa_public_key_2 = var.rsa_public_key_2
+
+  query_tag      = var.query_tag
+  timezone       = var.timezone
+  network_policy = var.network_policy
+
+  trace_level                          = var.trace_level
+  log_level                            = var.log_level
+  enable_unredacted_query_syntax_error = var.enable_unredacted_query_syntax_error
 }
 
 resource "snowflake_user" "defaults_not_enforced" {
-  count = module.this.enabled && var.ignore_changes_on_defaults ? 1 : 0
+  count = module.this.enabled && var.ignore_changes_on_defaults && upper(var.type) == "PERSON" ? 1 : 0
 
   name         = local.name_from_descriptor
   login_name   = var.login_name
   display_name = var.display_name
   comment      = var.comment
 
-  password             = one(random_password.this[*].result)
+  password             = var.generate_password ? one(random_password.this[*].result) : null
   must_change_password = var.must_change_password
+  disable_mfa          = var.disable_mfa
 
-  email      = var.email
-  first_name = var.first_name
-  last_name  = var.last_name
+  email       = var.email
+  first_name  = var.first_name
+  middle_name = var.middle_name
+  last_name   = var.last_name
 
-  default_namespace       = var.default_namespace
-  default_warehouse       = var.default_warehouse
-  default_role            = var.default_role
-  default_secondary_roles = var.default_secondary_roles
+  default_namespace              = var.default_namespace
+  default_warehouse              = var.default_warehouse
+  default_role                   = var.default_role
+  default_secondary_roles_option = var.default_secondary_roles_option #'DEFAULT', 'ALL', 'NONE'
 
   rsa_public_key   = local.rsa_public_key
   rsa_public_key_2 = var.rsa_public_key_2
+
+  query_tag      = var.query_tag
+  timezone       = var.timezone
+  network_policy = var.network_policy
+
+  trace_level                          = var.trace_level
+  log_level                            = var.log_level
+  enable_unredacted_query_syntax_error = var.enable_unredacted_query_syntax_error
 
   lifecycle {
     ignore_changes = [
@@ -77,6 +97,60 @@ resource "snowflake_user" "defaults_not_enforced" {
       default_role,
     ]
   }
+}
+
+resource "snowflake_service_user" "this" {
+  count = module.this.enabled && upper(var.type) == "SERVICE" ? 1 : 0
+
+  name         = local.name_from_descriptor
+  login_name   = var.login_name
+  display_name = var.display_name
+
+  comment = var.comment
+  email   = var.email
+
+  default_warehouse              = var.default_warehouse
+  default_secondary_roles_option = var.default_secondary_roles_option
+  default_role                   = var.default_role
+  default_namespace              = var.default_namespace
+
+  rsa_public_key   = local.rsa_public_key
+  rsa_public_key_2 = var.rsa_public_key_2
+
+  query_tag      = var.query_tag
+  timezone       = var.timezone
+  network_policy = var.network_policy
+
+  trace_level                          = var.trace_level
+  log_level                            = var.log_level
+  enable_unredacted_query_syntax_error = var.enable_unredacted_query_syntax_error
+}
+
+resource "snowflake_legacy_service_user" "this" {
+  count = module.this.enabled && upper(var.type) == "LEGACY_SERVICE" ? 1 : 0
+
+  name         = local.name_from_descriptor
+  login_name   = var.login_name
+  display_name = var.display_name
+
+  password             = var.generate_password ? one(random_password.this[*].result) : null
+  must_change_password = var.must_change_password
+
+  comment = var.comment
+  email   = var.email
+
+  default_warehouse              = var.default_warehouse
+  default_secondary_roles_option = var.default_secondary_roles_option
+  default_role                   = var.default_role
+  default_namespace              = var.default_namespace
+
+  query_tag      = var.query_tag
+  timezone       = var.timezone
+  network_policy = var.network_policy
+
+  trace_level                          = var.trace_level
+  log_level                            = var.log_level
+  enable_unredacted_query_syntax_error = var.enable_unredacted_query_syntax_error
 }
 
 resource "snowflake_grant_account_role" "default_role" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,55 +1,66 @@
 output "default_namespace" {
   description = "Specifies the namespace (database only or database and schema) that is active by default for the user's session upon login"
-  value       = one(local.snowflake_user[*].default_namespace)
+  value       = local.snowflake_user.default_namespace
 }
 
 output "default_role" {
   description = "Specifies the role that is active by default for the user's session upon login"
-  value       = one(local.snowflake_user[*].default_role)
+  value       = nonsensitive(local.snowflake_user.default_role)
 }
 
 output "default_warehouse" {
   description = "Specifies the virtual warehouse that is active by default for the user's session upon login"
-  value       = one(local.snowflake_user[*].default_warehouse)
+  value       = local.snowflake_user.default_warehouse
+}
+
+output "default_secondary_roles_option" {
+  description = "Specifies the secondary roles that are active for the user’s session upon login"
+  value       = local.snowflake_user.default_secondary_roles_option
 }
 
 output "disabled" {
   description = "Whether user account is disabled"
-  value       = one(local.snowflake_user[*].disabled)
+  value       = local.snowflake_user.disabled
 }
 
 output "login_name" {
   description = "The name users use to log in"
-  value       = one(local.snowflake_user[*].login_name)
+  value       = local.snowflake_user.login_name
+  sensitive   = true
 }
 
 output "name" {
   description = "Name of the user"
-  value       = nonsensitive(one(local.snowflake_user[*].name))
+  value       = local.snowflake_user.name
 }
 
 output "display_name" {
   description = "Name displayed for the user in the Snowflake web interface"
-  value       = one(local.snowflake_user[*].display_name)
+  value       = nonsensitive(local.snowflake_user.display_name)
 }
 
 output "first_name" {
-  description = "First name of the user"
-  value       = one(local.snowflake_user[*].first_name)
+  description = "First name of the user (only if `type == PERSON`)"
+  value       = var.type == "PERSON" ? local.snowflake_user.first_name : null
+}
+
+output "middle_name" {
+  description = "Middle name of the user (only if `type == PERSON`)"
+  value       = var.type == "PERSON" ? local.snowflake_user.middle_name : null
 }
 
 output "last_name" {
-  description = "Last name of the user"
-  value       = one(local.snowflake_user[*].last_name)
+  description = "Last name of the user (only if `type == PERSON`)"
+  value       = var.type == "PERSON" ? local.snowflake_user.last_name : null
 }
 
 output "email" {
   description = "Email address for the user"
-  value       = one(local.snowflake_user[*].email)
+  value       = local.snowflake_user.email
 }
 
 output "password" {
-  description = "Password set for the user"
+  description = "Password set for the user (only if `type == PERSON` or `type == LEGACY_SERVICE`)"
   value       = one(random_password.this[*].result)
   sensitive   = true
 }
@@ -58,4 +69,45 @@ output "rsa_private_key" {
   description = "RSA Private key used for authentication"
   value       = one(tls_private_key.this[*].private_key_pem)
   sensitive   = true
+}
+
+
+output "query_tag" {
+  description = "Query tag"
+  value       = local.snowflake_user.query_tag
+}
+
+output "timezone" {
+  description = "Timezone"
+  value       = local.snowflake_user.timezone
+}
+
+output "network_policy" {
+  description = "Network policy associated with the user"
+  value       = local.snowflake_user.network_policy
+}
+
+output "trace_level" {
+  description = "Trace level"
+  value       = local.snowflake_user.trace_level
+}
+
+output "log_level" {
+  description = "Log level"
+  value       = local.snowflake_user.log_level
+}
+
+output "enable_unredacted_query_syntax_error" {
+  description = "Enable access to unredacted query syntax error for the user"
+  value       = local.snowflake_user.enable_unredacted_query_syntax_error
+}
+
+output "disable_mfa" {
+  description = "Whether multi-factor authentication is disabled for the user"
+  value       = var.type == "PERSON" ? local.snowflake_user.disable_mfa : null
+}
+
+output "type" {
+  description = "User type"
+  value       = var.type
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,13 @@
+variable "type" {
+  description = "Type of the user. Valid values are PERSON, SERVICE, LEGACY_SERVICE"
+  type        = string
+  default     = "PERSON"
+  validation {
+    condition     = contains(["PERSON", "SERVICE", "LEGACY_SERVICE"], var.type)
+    error_message = "Only PERSON, SERVICE, LEGACY_SERVICE values are supported by Snowflake provider."
+  }
+}
+
 variable "login_name" {
   description = "The name users use to log in. If not supplied, snowflake will use name instead."
   type        = string
@@ -23,13 +33,19 @@ variable "email" {
 }
 
 variable "first_name" {
-  description = "First name of the user"
+  description = "First name of the user (works only with `type = PERSON`)"
+  type        = string
+  default     = null
+}
+
+variable "middle_name" {
+  description = "Middle name of the user (works only with `type = PERSON`)"
   type        = string
   default     = null
 }
 
 variable "last_name" {
-  description = "Last name of the user"
+  description = "Last name of the user (works only with `type = PERSON`)"
   type        = string
   default     = null
 }
@@ -52,17 +68,16 @@ variable "default_role" {
   default     = null
 }
 
-variable "default_secondary_roles" {
+variable "default_secondary_roles_option" {
   description = <<EOT
-    Specifies the set of secondary roles that are active for the user's session upon login. 
-    Secondary roles are a set of roles that authorize any SQL action other than the execution of CREATE <object> statements. 
-    Currently only ["ALL"] value is supported
+    Specifies the secondary roles that are active for the user’s session upon login. 
+    Valid values are (case-insensitive): DEFAULT | NONE | ALL
   EOT
-  type        = list(string)
-  default     = []
+  type        = string
+  default     = "DEFAULT"
   validation {
-    condition     = var.default_secondary_roles == null || contains([0, 1], length(var.default_secondary_roles)) || contains(var.default_secondary_roles, "ALL")
-    error_message = "Currently only [\"ALL\"] value is supported by Snowflake provider."
+    condition     = contains(["DEFAULT", "ALL", "NONE"], var.default_secondary_roles_option)
+    error_message = "Only DEFAULT | NONE | ALL value is supported by Snowflake provider."
   }
 }
 
@@ -118,7 +133,53 @@ variable "grant_default_roles" {
 }
 
 variable "ignore_changes_on_defaults" {
-  description = "Whether to ignore configuration of `default_warehouse`, `default_role` and `default_namespace`"
+  description = "Whether to ignore configuration of `default_warehouse`, `default_role` and `default_namespace` (works only with `type = PERSON`)"
+  type        = bool
+  default     = false
+}
+
+variable "query_tag" {
+  description = "Optional string that can be used to tag queries and other SQL statements executed within a session."
+  type        = string
+  default     = null
+}
+
+variable "timezone" {
+  description = "Specifies the time zone for the session. You can specify a time zone name or a link name from release 2021a of the IANA Time Zone Database (e.g. America/Los_Angeles, Europe/London, UTC, Etc/GMT, etc.)."
+  type        = string
+  default     = null
+}
+
+variable "network_policy" {
+  description = " Specifies the network policy to enforce for your account. Network policies enable restricting access to your account based on users’ IP address."
+  type        = string
+  default     = null
+}
+
+variable "trace_level" {
+  description = "Controls how trace events are ingested into the event table."
+  type        = string
+  default     = null
+}
+
+variable "log_level" {
+  description = "Specifies the severity level of messages that should be ingested and made available in the active event table. Messages at the specified level (and at more severe levels) are ingested."
+  type        = string
+  default     = null
+}
+
+variable "enable_unredacted_query_syntax_error" {
+  description = <<EOT
+    Controls whether query text is redacted if a SQL query fails due to a syntax or parsing error. If FALSE, the content of a failed query is redacted in the views, pages, and functions that provide a query history. 
+    Only users with a role that is granted or inherits the AUDIT privilege can set the ENABLE_UNREDACTED_QUERY_SYNTAX_ERROR parameter. 
+    When using the ALTER USER command to set the parameter to TRUE for a particular user, modify the user that you want to see the query text, not the user who executed the query (if those are different users).
+  EOT
+  type        = bool
+  default     = null
+}
+
+variable "disable_mfa" {
+  description = "Disable Multi-Factor Authentication for the user (works only with `type = PERSON`)"
   type        = bool
   default     = false
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     snowflake = {
       source  = "Snowflake-Labs/snowflake"
-      version = "~> 0.94"
+      version = "~> 0.96"
     }
     tls = {
       source  = "hashicorp/tls"


### PR DESCRIPTION
**BREAKING CHANGE**
Changes:

* Support for Snowflake user types, managed by `type` variable
* Clear differentiation of `PERSON`, `SERVICE` and `LEGACY_SERVICE` users
* `snowflake_default_secondary_roles` changed to `snowflake_default_secondary_roles_option` (string)
* Added `middle_name`, `query_tag`, `timezone`, `network_policy`, `trace_level`, `log_level` and `enable_unredacted_query_syntax_error` variables
* Added `disable_mfa` flag (`false` by default), that handles MFA enforcement for `PERSON` users
